### PR TITLE
Fatal error:Class 'Netzmacht\ColumnSet\Hooks' not.

### DIFF
--- a/src/system/modules/subcolumns_bootstrap_customizable/config/autoload.php
+++ b/src/system/modules/subcolumns_bootstrap_customizable/config/autoload.php
@@ -30,6 +30,7 @@ ClassLoader::addClasses(array
 
 	// Classes
 	'Netzmacht\ColumnSet\ColumnSet'   => 'system/modules/subcolumns_bootstrap_customizable/classes/ColumnSet.php',
+	'Netzmacht\ColumnSet\Hooks'   => 'system/modules/subcolumns_bootstrap_customizable/classes/Hooks.php',
 
 	// Elements
 	'Netzmacht\ColumnSet\colsetStart' => 'system/modules/subcolumns_bootstrap_customizable/elements/colsetStart.php',


### PR DESCRIPTION
A »Fatal error« appears  because the Hooks:: isVisibleElement()
method is is defined for Array $GLOBALS['TL_HOOKS']['isVisibleElement'][] in Line:15 > config.php.
The proclamation for the ClassLoader is missed in autoload.php.
With the added line, the Fatal error is past.

I hope it will help
Martin
